### PR TITLE
add support for custom headers and http.Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ go get -u github.com/joeig/go-powerdns
 ```go
 import "github.com/joeig/go-powerdns"
 
-pdns := powerdns.NewClient("http://localhost:80", "localhost", "apipw")
+headers := make(map[string]string)
+headers["X-API-Key"] = "apipw"
+pdns := powerdns.NewClient("http://localhost:80", "localhost", headers, nil)
 ```
 
 Assuming that the server is listening on http://localhost:80 for virtual host `localhost`, the API password is `apipw` and you want to edit the domain `example.com`.

--- a/cryptokeys_test.go
+++ b/cryptokeys_test.go
@@ -1,9 +1,10 @@
 package powerdns
 
 import (
-	"gopkg.in/jarcoal/httpmock.v1"
 	"net/http"
 	"testing"
+
+	"gopkg.in/jarcoal/httpmock.v1"
 )
 
 func TestGetCryptokeys(t *testing.T) {
@@ -71,7 +72,9 @@ func TestGetCryptokeys(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	z, err := p.GetZone("example.com")
 	cryptokeys, err := z.GetCryptokeys()
 	if err != nil {
@@ -132,7 +135,9 @@ func TestGetCryptokey(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	z, err := p.GetZone("example.com")
 	cryptokey, err := z.GetCryptokey("11")
 	if err != nil {
@@ -201,7 +206,9 @@ func TestToggleCryptokey(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	z, err := p.GetZone("example.com")
 	c, err := z.GetCryptokey("11")
 	if c.ToggleCryptokey() != nil {
@@ -267,7 +274,9 @@ func TestDeleteCryptokey(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	z, err := p.GetZone("example.com")
 	c, err := z.GetCryptokey("11")
 	if c.DeleteCryptokey() != nil {

--- a/powerdns_test.go
+++ b/powerdns_test.go
@@ -6,16 +6,20 @@ import (
 )
 
 func TestNewClientHTTP(t *testing.T) {
-	tmpl := &PowerDNS{"http", "localhost", "8080", "localhost", "apipw"}
-	p := NewClient("http://localhost:8080", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	tmpl := &PowerDNS{"http", "localhost", "8080", "localhost", headers, nil}
+	p := NewClient("http://localhost:8080", "localhost", headers, nil)
 	if !reflect.DeepEqual(tmpl, p) {
 		t.Error("NewClient returns invalid PowerDNS object")
 	}
 }
 
 func TestNewClientHTTPS(t *testing.T) {
-	tmpl := &PowerDNS{"https", "localhost", "443", "localhost", "apipw"}
-	p := NewClient("https://localhost", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	tmpl := &PowerDNS{"https", "localhost", "443", "localhost", headers, nil}
+	p := NewClient("https://localhost", "localhost", headers, nil)
 	if !reflect.DeepEqual(tmpl, p) {
 		t.Error("NewClient returns invalid PowerDNS object")
 	}

--- a/servers_test.go
+++ b/servers_test.go
@@ -1,9 +1,10 @@
 package powerdns
 
 import (
-	"gopkg.in/jarcoal/httpmock.v1"
 	"net/http"
 	"testing"
+
+	"gopkg.in/jarcoal/httpmock.v1"
 )
 
 func TestGetServers(t *testing.T) {
@@ -29,7 +30,9 @@ func TestGetServers(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	servers, err := p.GetServers()
 	if err != nil {
 		t.Errorf("%s", err)
@@ -60,7 +63,9 @@ func TestGetServer(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	server, err := p.GetServer()
 	if err != nil {
 		t.Errorf("%s", err)

--- a/statistics_test.go
+++ b/statistics_test.go
@@ -1,9 +1,10 @@
 package powerdns
 
 import (
-	"gopkg.in/jarcoal/httpmock.v1"
 	"net/http"
 	"testing"
+
+	"gopkg.in/jarcoal/httpmock.v1"
 )
 
 func TestGetStatistics(t *testing.T) {
@@ -55,7 +56,9 @@ func TestGetStatistics(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	statistics, err := p.GetStatistics()
 	if err != nil {
 		t.Errorf("%s", err)

--- a/zones_test.go
+++ b/zones_test.go
@@ -1,9 +1,10 @@
 package powerdns
 
 import (
-	"gopkg.in/jarcoal/httpmock.v1"
 	"net/http"
 	"testing"
+
+	"gopkg.in/jarcoal/httpmock.v1"
 )
 
 func TestGetZones(t *testing.T) {
@@ -28,7 +29,9 @@ func TestGetZones(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	zones, err := p.GetZones()
 	if err != nil {
 		t.Errorf("%s", err)
@@ -70,7 +73,9 @@ func TestGetZone(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	zone, err := p.GetZone("example.com")
 	if err != nil {
 		t.Errorf("%s", err)
@@ -104,7 +109,9 @@ func TestNotify(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	z, err := p.GetZone("example.com")
 	if err != nil {
 		t.Errorf("%s", err)
@@ -146,7 +153,9 @@ func TestAddRecord(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	z, err := p.GetZone("example.com")
 	if err != nil {
 		t.Errorf("%s", err)
@@ -184,7 +193,9 @@ func TestChangeRecord(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	z, err := p.GetZone("example.com")
 	if err != nil {
 		t.Errorf("%s", err)
@@ -222,7 +233,9 @@ func TestDeleteRecord(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	z, err := p.GetZone("example.com")
 	if err != nil {
 		t.Errorf("%s", err)
@@ -256,7 +269,9 @@ func TestExport(t *testing.T) {
 		},
 	)
 
-	p := NewClient("http://localhost:8080/", "localhost", "apipw")
+	headers := make(map[string]string)
+	headers["X-API-Key"] = "apipw"
+	p := NewClient("http://localhost:8080/", "localhost", headers, nil)
 	z, err := p.GetZone("example.com")
 	if err != nil {
 		t.Errorf("%s", err)


### PR DESCRIPTION
It's useful to be able to use custom http headers, so that we could use pdns api behind nginx making possible to handle multi user/key auth in another layer. I've also added the possibility of using a custom http.Client. I would also allow people to do skip verify and tweak timeouts without hacking the code. 