### PR TITLE
Edit RRset struct

### DIFF
--- a/records.go
+++ b/records.go
@@ -13,7 +13,7 @@ type RRset struct {
 	Type       *string   `json:"type,omitempty"`
 	TTL        *uint32   `json:"ttl,omitempty"`
 	ChangeType *string   `json:"changetype,omitempty"`
-	Records    []Record  `json:"records,omitempty"`
+	Records    []Record  `json:"records"`
 	Comments   []Comment `json:"comments,omitempty"`
 }
 


### PR DESCRIPTION
`Records` should always be present in RRset REPLACE. Without it, it will not be possible to completely delete a RRset, passsing and empty `Records` list, because PDNS will throw:

`422 No change for RRset <recordName> IN A`