### PR TITLE
Fixed CNAME Records Creation

### DIFF
--- a/records.go
+++ b/records.go
@@ -71,6 +71,12 @@ func (r *RecordsService) Delete(domain string, name string, recordType string) e
 func (r *RecordsService) patchRRset(domain string, rrset RRset) error {
 	rrset.Name = String(makeDomainCanonical(*rrset.Name))
 
+	if *rrset.Type == "CNAME" {
+		for i, _ := range rrset.Records {
+			rrset.Records[i].Content = String(makeDomainCanonical(*rrset.Records[i].Content))
+		}
+	}
+
 	payload := RRsets{}
 	payload.Sets = append(payload.Sets, rrset)
 

--- a/records.go
+++ b/records.go
@@ -72,7 +72,7 @@ func (r *RecordsService) patchRRset(domain string, rrset RRset) error {
 	rrset.Name = String(makeDomainCanonical(*rrset.Name))
 
 	if *rrset.Type == "CNAME" {
-		for i, _ := range rrset.Records {
+		for i := range rrset.Records {
 			rrset.Records[i].Content = String(makeDomainCanonical(*rrset.Records[i].Content))
 		}
 	}


### PR DESCRIPTION
For CNAME records, value should be expressed as canonical name record, or powerdns will trigger `CNAME not in exprected format` error