### PR TITLE
Fix: MX records value should be canonical

### DIFF
--- a/records.go
+++ b/records.go
@@ -164,7 +164,7 @@ func (r *RecordsService) Delete(domain string, name string, recordType RRType) e
 	return r.patchRRset(domain, *rrset)
 }
 
-func fixCNAMEResourceRecordValues(records []Record) {
+func fixResourceRecordValues(records []Record) {
 	for i := range records {
 		records[i].Content = String(makeDomainCanonical(*records[i].Content))
 	}
@@ -173,8 +173,8 @@ func fixCNAMEResourceRecordValues(records []Record) {
 func (r *RecordsService) patchRRset(domain string, rrset RRset) error {
 	rrset.Name = String(makeDomainCanonical(*rrset.Name))
 
-	if *rrset.Type == RRTypeCNAME {
-		fixCNAMEResourceRecordValues(rrset.Records)
+	if *rrset.Type == RRTypeCNAME || *rrset.Type == RRTypeMX {
+		fixResourceRecordValues(rrset.Records)
 	}
 
 	payload := RRsets{}

--- a/records_test.go
+++ b/records_test.go
@@ -176,7 +176,7 @@ func TestDeleteRecordError(t *testing.T) {
 	}
 }
 
-func TestFixCNAMEResourceRecordValues(t *testing.T) {
+func TestFixResourceRecordValues(t *testing.T) {
 	testCases := []struct {
 		records     []Record
 		wantContent []string
@@ -188,7 +188,7 @@ func TestFixCNAMEResourceRecordValues(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("TestCase%d", i), func(t *testing.T) {
-			fixCNAMEResourceRecordValues(tc.records)
+			fixResourceRecordValues(tc.records)
 			for j := range tc.records {
 				isContent := *tc.records[j].Content
 				wantContent := tc.wantContent[j]


### PR DESCRIPTION
For MX records, according to [RFC 1035](https://tools.ietf.org/html/rfc1035#section-3.3.9) value should be expressed as FQDN. Therefore, value should be expressed ad canonical name record, or powerdns will trigger `MX not in exprected format error`