### PR TITLE
Added one-argument Zone Add method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ zones, err := pdns.Zones.List()
 zone, err := pdns.Zones.Get("example.com")
 export, err := pdns.Zones.Export("example.com")
 zone, err := pdns.Zones.AddNative("example.com", true, "", false, "foo", "foo", true, []string{"ns.foo.tld."})
+zone, err := pdns.Zones.Add(&powerdns.Zone{})
 err := pdns.Zones.Change("example.com", &zone)
 err := pdns.Zones.Delete("example.com")
 ```

--- a/zones.go
+++ b/zones.go
@@ -135,6 +135,11 @@ func (z *ZonesService) AddSlave(domain string, masters []string) (*Zone, error) 
 	return z.postZone(&zone)
 }
 
+// Add pre-created zone
+func (z *ZonesService) Add(zone *Zone) (*Zone, error) {
+	return z.postZone(zone)
+}
+
 func (z *ZonesService) postZone(zone *Zone) (*Zone, error) {
 	zone.Name = String(makeDomainCanonical(*zone.Name))
 	zone.Type = ZoneTypePtr(ZoneZoneType)

--- a/zones_test.go
+++ b/zones_test.go
@@ -393,6 +393,50 @@ func TestAddSlaveZoneError(t *testing.T) {
 	}
 }
 
+func TestAddZone(t *testing.T) {
+	testDomain := generateTestZone(false)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	registerZoneMockResponder(testDomain, MasterZoneKind)
+
+	p := initialisePowerDNSTestClient()
+
+	z := Zone{
+		Name:        String(testDomain),
+		Kind:        ZoneKindPtr(MasterZoneKind),
+		DNSsec:      Bool(true),
+		Nsec3Param:  String(""),
+		Nsec3Narrow: Bool(false),
+		SOAEdit:     String("foo"),
+		SOAEditAPI:  String("foo"),
+		APIRectify:  Bool(true),
+		Nameservers: []string{"ns.foo.tld."},
+	}
+
+	zone, err := p.Zones.Add(&z)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	if *zone.ID != makeDomainCanonical(testDomain) || *zone.Kind != MasterZoneKind {
+		t.Error("Zone wasn't created")
+	}
+}
+
+func TestAddZoneError(t *testing.T) {
+	testDomain := generateTestZone(false)
+	p := initialisePowerDNSTestClient()
+	p.Port = "x"
+
+	z := Zone{
+		Name: String(testDomain),
+	}
+
+	if _, err := p.Zones.Add(&z); err == nil {
+		t.Error("error is nil")
+	}
+}
+
 func TestChangeZone(t *testing.T) {
 	testDomain := generateTestZone(true)
 


### PR DESCRIPTION
It's good to use implemented here data model for other projects as for example REST controllers body.
But current implementation forces users to put each parameter of zone into Add methods as arguments again even if we already made object from body. 

In my case it looks weird:
```
createdZone, err := pwdClient.Zones.AddMaster(*(zone.Name), *(zone.DNSsec), *(zone.Nsec3Param),(zone.Nsec3Narrow), *(zone.SOAEdit), *(zone.SOAEditAPI), *(zone.APIRectify), zone.Nameservers)
```
---

This simplification(improvement) helps to avoid the shifting.  

---
FYI
I was thinking to rename *postZone* method into *Add* or make it public, but I've decided to keep your common style.

Thank you.