### PR TITLE
Fixed Error handling errors. Added patch for records.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,8 +4,8 @@ import "fmt"
 
 // Error structure with JSON API metadata
 type Error struct {
-	Status     string
-	StatusCode int
+	StatusCode int    `json:"-"`
+	Status     string `json:"-"`
 	Message    string `json:"error"`
 }
 

--- a/errors.go
+++ b/errors.go
@@ -4,8 +4,9 @@ import "fmt"
 
 // Error structure with JSON API metadata
 type Error struct {
-	Status  string
-	Message string `json:"error"`
+	Status     string
+	StatusCode int
+	Message    string `json:"error"`
 }
 
 func (e Error) Error() string {

--- a/powerdns.go
+++ b/powerdns.go
@@ -135,8 +135,8 @@ func (p *Client) newRequest(method string, path string, query *url.Values, body 
 
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
 	}
-	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "go-powerdns")
 
 	for key, value := range p.Headers {

--- a/powerdns.go
+++ b/powerdns.go
@@ -188,7 +188,7 @@ func (p *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
 		}
 	}
 
-	if v != nil {
+	if v != nil && resp.StatusCode != 204 {
 		defer func() {
 			_ = resp.Body.Close()
 		}()

--- a/powerdns.go
+++ b/powerdns.go
@@ -188,7 +188,7 @@ func (p *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
 		}
 	}
 
-	if v != nil && resp.StatusCode != 204 {
+	if v != nil && resp.StatusCode != http.StatusNoContent {
 		defer func() {
 			_ = resp.Body.Close()
 		}()

--- a/powerdns.go
+++ b/powerdns.go
@@ -154,8 +154,9 @@ func (p *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
 
 	if resp.StatusCode == 401 {
 		return resp, &Error{
-			Status:  resp.Status,
-			Message: "Unauthorized",
+			Status:     resp.Status,
+			StatusCode: resp.StatusCode,
+			Message:    "Unauthorized",
 		}
 	}
 
@@ -181,8 +182,9 @@ func (p *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
 		}
 
 		return resp, &Error{
-			Status:  resp.Status,
-			Message: message,
+			Status:     resp.Status,
+			StatusCode: resp.StatusCode,
+			Message:    message,
 		}
 	}
 

--- a/powerdns.go
+++ b/powerdns.go
@@ -166,13 +166,13 @@ func (p *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
 		}()
 		var message string
 
-		if resp.Header.Get("Accept") == "application/json" {
+		if resp.Header.Get("Content-Type") == "application/json" {
 			apiError := new(Error)
-			err = json.NewDecoder(resp.Body).Decode(apiError)
+			err = json.NewDecoder(resp.Body).Decode(&apiError)
 			if err != nil {
 				return resp, err
 			}
-			message = err.(*Error).Message
+			message = apiError.Message
 		} else {
 			messageBytes, err := ioutil.ReadAll(resp.Body)
 			if err != nil {

--- a/powerdns.go
+++ b/powerdns.go
@@ -137,7 +137,6 @@ func (p *Client) newRequest(method string, path string, query *url.Values, body 
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Accept", "application/json")
-
 	req.Header.Set("User-Agent", "go-powerdns")
 
 	for key, value := range p.Headers {

--- a/powerdns.go
+++ b/powerdns.go
@@ -168,16 +168,10 @@ func (p *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
 
 		if resp.Header.Get("Content-Type") == "application/json" {
 			apiError := new(Error)
-			err = json.NewDecoder(resp.Body).Decode(&apiError)
-			if err != nil {
-				return resp, err
-			}
+			_ = json.NewDecoder(resp.Body).Decode(&apiError)
 			message = apiError.Message
 		} else {
-			messageBytes, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				return resp, err
-			}
+			messageBytes, _ := ioutil.ReadAll(resp.Body)
 			message = string(messageBytes)
 		}
 

--- a/powerdns_test.go
+++ b/powerdns_test.go
@@ -123,7 +123,7 @@ func TestDo(t *testing.T) {
 	})
 	t.Run("TestJSONResponseHandling", func(t *testing.T) {
 		req, _ := p.newRequest("GET", "server", nil, &Server{})
-		if _, err := p.do(req, nil); err.(*Error).Message != "Not Found" {
+		if _, err := p.do(req, nil); err.Error() != "Not Found" {
 			t.Error("501 JSON response does not result into Error structure")
 		}
 	})

--- a/powerdns_test.go
+++ b/powerdns_test.go
@@ -100,15 +100,15 @@ func TestDo(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	registerDoMockResponder()
 
-	p := initialisePowerDNSTestClient()
-
 	t.Run("TestStringErrorResponse", func(t *testing.T) {
+		p := initialisePowerDNSTestClient()
 		req, _ := p.newRequest("GET", "servers/doesntExist", nil, nil)
 		if _, err := p.do(req, nil); err == nil {
 			t.Error("err is nil")
 		}
 	})
 	t.Run("Test401Handling", func(t *testing.T) {
+		p := initialisePowerDNSTestClient()
 		p.Headers = nil
 		req, _ := p.newRequest("GET", "servers", nil, nil)
 		if _, err := p.do(req, nil); err == nil {
@@ -116,12 +116,14 @@ func TestDo(t *testing.T) {
 		}
 	})
 	t.Run("Test404Handling", func(t *testing.T) {
+		p := initialisePowerDNSTestClient()
 		req, _ := p.newRequest("GET", "servers/doesntExist", nil, nil)
 		if _, err := p.do(req, nil); err.Error() != "Not Found" {
 			t.Error("404 response does not result into an error")
 		}
 	})
 	t.Run("TestJSONResponseHandling", func(t *testing.T) {
+		p := initialisePowerDNSTestClient()
 		req, _ := p.newRequest("GET", "server", nil, &Server{})
 		if _, err := p.do(req, nil); err.Error() != "Not Found" {
 			t.Error("501 JSON response does not result into Error structure")

--- a/powerdns_test.go
+++ b/powerdns_test.go
@@ -46,8 +46,9 @@ func registerDoMockResponder() {
 	httpmock.RegisterResponder("GET", fmt.Sprintf("%s/server", generateTestAPIURL()),
 		func(req *http.Request) (*http.Response, error) {
 			mock := Error{
-				Status:  "Not Found",
-				Message: "Not Found",
+				Status:     "Not Found",
+				StatusCode: http.StatusNotFound,
+				Message:    "Not Found",
 			}
 			return httpmock.NewJsonResponse(http.StatusNotImplemented, mock)
 		},

--- a/powerdns_test.go
+++ b/powerdns_test.go
@@ -117,7 +117,7 @@ func TestDo(t *testing.T) {
 	})
 	t.Run("Test404Handling", func(t *testing.T) {
 		req, _ := p.newRequest("GET", "servers/doesntExist", nil, nil)
-		if _, err := p.do(req, nil); err == nil {
+		if _, err := p.do(req, nil); err.Error() != "Not Found" {
 			t.Error("404 response does not result into an error")
 		}
 	})

--- a/records_test.go
+++ b/records_test.go
@@ -246,8 +246,10 @@ func TestPatchRRSets(t *testing.T) {
 
 	testRecordName := generateTestRecord(p, testDomain, true)
 	registerRecordMockResponder(testDomain)
+
 	rrSets := RRsets{}
-	rrSets.Sets = []RRset{{Name: &testRecordName, Type: RRTypePtr(RRTypeTXT),
+	rrSetName := makeDomainCanonical(testRecordName)
+	rrSets.Sets = []RRset{{Name: &rrSetName, Type: RRTypePtr(RRTypeTXT),
 		ChangeType: ChangeTypePtr(ChangeTypeDelete)}}
 
 	if err := p.Records.Patch(testDomain, &rrSets); err != nil {

--- a/records_test.go
+++ b/records_test.go
@@ -213,7 +213,7 @@ func TestFixRRset(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("TestCase%d", i), func(t *testing.T) {
-			fixRRset(&tc.rrset)
+			fixRRSet(&tc.rrset)
 
 			if tc.wantFixedCanonicalRecords {
 				for j := range tc.rrset.Records {
@@ -233,5 +233,24 @@ func TestFixRRset(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPatchRRSets(t *testing.T) {
+	testDomain := generateTestZone(true)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	p := initialisePowerDNSTestClient()
+
+	testRecordName := generateTestRecord(p, testDomain, true)
+	registerRecordMockResponder(testDomain)
+	rrSets := RRsets{}
+	rrSets.Sets = []RRset{{Name: &testRecordName, Type: RRTypePtr(RRTypeTXT),
+		ChangeType: ChangeTypePtr(ChangeTypeDelete)}}
+
+	if err := p.Records.Patch(testDomain, &rrSets); err != nil {
+		t.Errorf("%s", err)
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,3 @@
 # github.com/jarcoal/httpmock v1.0.4
 ## explicit
 github.com/jarcoal/httpmock
-# github.com/mittwald/go-powerdns v0.4.0
-## explicit

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,5 @@
 # github.com/jarcoal/httpmock v1.0.4
 ## explicit
 github.com/jarcoal/httpmock
+# github.com/mittwald/go-powerdns v0.4.0
+## explicit

--- a/zones_test.go
+++ b/zones_test.go
@@ -261,6 +261,13 @@ func registerZoneMockResponder(testDomain string, zoneKind ZoneKind) {
 				return httpmock.NewBytesResponse(http.StatusBadRequest, []byte{}), nil
 			}
 
+			acceptHeader := req.Header.Get("Accept")
+
+			if acceptHeader != "" && acceptHeader != "text/html" {
+				log.Print("Accept type must be text/html")
+				return httpmock.NewBytesResponse(http.StatusBadRequest, []byte{}), nil
+			}
+
 			return httpmock.NewStringResponse(http.StatusOK, makeDomainCanonical(testDomain)+"	3600	SOA	a.misconfigured.powerdns.server. hostmaster."+makeDomainCanonical(testDomain)+" 1 10800 3600 604800 3600"), nil
 		},
 	)


### PR DESCRIPTION
Hello!
1) req.Header.Set("Accept", "application/json") moved out of if above to make all responses json formatted.
2) Added field StatusCode to the Error response.
3) Ignored json deserialization for Status and Status Code in Error (I left *Status* property for backward compatibility, but for me it's not clear what it was intended for to be in Error object.) 
4) Fixed tests. Sometimes powerdns tests were failing because of reusing mocks in different tests. 
5) Test404Handling was not working correct because of totally different response error.
6) Added patch method to create rrsets as bulk object with already precreated body.
7) I left [this logic](url), but it could be deleted I think, has to be reviewed 

Looking forward to review :) 
Thank you!