### PR TITLE
Fix Coveralls integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,19 +36,9 @@ jobs:
         uses: actions/checkout@v1
       - name: Make
         run: make
-      - name: Convert coverage to lcov
-        uses: jandelgado/gcov2lcov-action@v1.0.0
-        with:
-          infile: c.out
-          outfile: c.lcov
-      - name: Coveralls Parallel
-        uses: coverallsapp/github-action@v1.0.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: c.lcov
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@v1.0.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
+      - name: Coveralls
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          go get github.com/mattn/goveralls
+          $(go env GOPATH)/bin/goveralls -coverprofile=c.out -service=github


### PR DESCRIPTION
* [x] Does your submission pass all tests against mocks? `make test`
* [x] Does your submission pass all tests against a real instance running PowerDNS Authoritative Server 4.1, 4.2 and 4.3? `docker-compose -f docker-compose-v4.3.yml up && make test-without-mocks`
* [x] Do your tests meet or exceed the coverage results of the master branch? `make coverage && go tool cover -html=c.out`
* [x] Does your submission pass the format guidelines? `make check-fmt`

Furthermore, the pipeline performs additional checks against your submission:

* [x] Does your submission comply with common best practices? `golangci-lint run && staticcheck ./...`
