### PR TITLE
Do not set Nsec3Param if DNSsec is disabled

### DIFF
--- a/zones.go
+++ b/zones.go
@@ -165,6 +165,9 @@ func (z *ZonesService) Change(ctx context.Context, domain string, zone *Zone) er
 	zone.Name = nil
 	zone.Type = nil
 	zone.URL = nil
+	if zone.DNSsec != nil && !*zone.DNSsec {
+		zone.Nsec3Param = nil
+	}
 
 	req, err := z.client.newRequest(ctx, "PUT", fmt.Sprintf("servers/%s/zones/%s", z.client.VHost, trimDomain(domain)), nil, zone)
 	if err != nil {


### PR DESCRIPTION
* [x] Does your submission pass all tests against mocks? `make test`
* [x] Does your submission pass all tests against a real instance running PowerDNS Authoritative Server 4.3? `docker-compose -f docker-compose-v4.3.yml up && make test-without-mocks`
* [x] Do your tests meet or exceed the coverage results of the master branch? `make coverage && go tool cover -html=c.out`
* [x] Does your submission pass the format guidelines? `make check-fmt`

Furthermore, the pipeline performs additional checks against your submission:

* [x] Does your submission comply with common best practices? `golangci-lint run && staticcheck ./...`
