### PR TITLE
Support Go 1.18, drop Go 1.15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up Go ${{ matrix.goVer }}
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: GolangCI-Lint
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goVer: [1.15, 1.16, 1.17]
+        goVer: [1.16, 1.17, 1.18]
     steps:
       - name: Set up Go ${{ matrix.goVer }}
         uses: actions/setup-go@v1
@@ -40,5 +40,5 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          go get github.com/mattn/goveralls
+          go install github.com/mattn/goveralls@latest
           $(go env GOPATH)/bin/goveralls -coverprofile=c.out -service=github

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [examples](https://github.com/joeig/go-powerdns/tree/master/examples).
 - PowerDNS 4.x ("API v1")
   - `--webserver=yes --api=yes --api-key=apipw --api-readonly=no`
   - Note that API v1 is actively maintained. There are major differences between 3.x, 4.0 and 4.1 and this client works only with 4.1 to 4.4.
-- Tested with Go version 1.15/1.16/1.17, according to [Go's version support policy](https://golang.org/doc/devel/release.html#policy) (should work with other minor releases as well)
+- Tested with Go version 1.16/1.17/1.18, according to [Go's version support policy](https://golang.org/doc/devel/release.html#policy) (should work with other minor releases as well)
 
 ### Install from source
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/joeig/go-powerdns/v3
 
-go 1.17
+go 1.16
 
 require github.com/jarcoal/httpmock v1.0.4


### PR DESCRIPTION
* [ ] Does your submission pass all tests against mocks? `make test`
* [ ] Does your submission pass all tests against a real instance running PowerDNS Authoritative Server 4.1, 4.2 and 4.3? `docker-compose -f docker-compose-v4.3.yml up && make test-without-mocks`
* [ ] Do your tests meet or exceed the coverage results of the master branch? `make coverage && go tool cover -html=c.out`
* [ ] Does your submission pass the format guidelines? `make check-fmt`

Furthermore, the pipeline performs additional checks against your submission:

* [ ] Does your submission comply with common best practices? `golangci-lint run && staticcheck ./...`
