### PR TITLE
add Catalog and EditedSerial to Zone struct

### DIFF
--- a/zones.go
+++ b/zones.go
@@ -70,6 +70,10 @@ const (
 	MasterZoneKind ZoneKind = "Master"
 	// SlaveZoneKind sets the zone's kind to slave
 	SlaveZoneKind ZoneKind = "Slave"
+	// ProducerZoneKind sets the zone's kind to producer
+	ProducerZoneKind ZoneKind = "Producer"
+	// ConsumerZoneKind sets the zone's kind to consumer
+	ConsumerZoneKind ZoneKind = "Consumer"
 )
 
 // List retrieves a list of Zones

--- a/zones.go
+++ b/zones.go
@@ -19,6 +19,7 @@ type Zone struct {
 	RRsets           []RRset   `json:"rrsets,omitempty"`
 	Serial           *uint32   `json:"serial,omitempty"`
 	NotifiedSerial   *uint32   `json:"notified_serial,omitempty"`
+	EditedSerial     *uint32   `json:"edited_serial,omitempty"`
 	Masters          []string  `json:"masters,omitempty"`
 	DNSsec           *bool     `json:"dnssec,omitempty"`
 	Nsec3Param       *string   `json:"nsec3param,omitempty"`
@@ -28,6 +29,7 @@ type Zone struct {
 	SOAEditAPI       *string   `json:"soa_edit_api,omitempty"`
 	APIRectify       *bool     `json:"api_rectify,omitempty"`
 	Zone             *string   `json:"zone,omitempty"`
+	Catalog          *string   `json:"catalog.omitempty"`
 	Account          *string   `json:"account,omitempty"`
 	Nameservers      []string  `json:"nameservers,omitempty"`
 	MasterTSIGKeyIDs []string  `json:"master_tsig_key_ids,omitempty"`

--- a/zones_test.go
+++ b/zones_test.go
@@ -456,6 +456,7 @@ func TestAddZone(t *testing.T) {
 		SOAEdit:     String("foo"),
 		SOAEditAPI:  String("foo"),
 		APIRectify:  Bool(true),
+		Catalog:     String("test.catalog"),
 		Nameservers: []string{"ns.foo.tld."},
 	}
 


### PR DESCRIPTION
I have added EditedSerial and Catalog fields to the Zone record to mach pdns  4.7 api  json spec, this allows the use of `func (z *ZonesService) Add(ctx context.Context, zone *Zone)` to create zones in a catalog, while not breaking backwards compatibility.

 