### PR TITLE
Support query parameters on fetching rrsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ err := pdns.Zones.Delete(ctx, "example.com")
 err := pdns.Records.Add(ctx, "example.com", "www.example.com", powerdns.RRTypeAAAA, 60, []string{"::1"})
 err := pdns.Records.Change(ctx, "example.com", "www.example.com", powerdns.RRTypeAAAA, 3600, []string{"::1"})
 err := pdns.Records.Delete(ctx, "example.com", "www.example.com", powerdns.RRTypeA)
+records, err := pdns.Records.Get(ctx, "example.com", "www.example.com", powerdns.RRTypePtr(powerdns.RRTypeA))
 ```
 
 ### Request server information and statistics


### PR DESCRIPTION
Supports filtering rrsets when retrieving a Zone via query params. 

https://doc.powerdns.com/authoritative/http-api/zone.html#get--servers-server_id-zones-zone_id

Example #1 - A records for www.example.com
```go
records, err := pdns.Records.Get(ctx, "example.com", "www.example.com", powerdns.RRTypePtr(powerdns.RRTypeA))
```

Example #2 - All records for www.example.com regardless of type
```go
records, err := pdns.Records.Get(ctx, "example.com", "www.example.com", nil)
```