### PR TITLE
Add TSIGKeys API

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ cryptokey, err := pdns.Cryptokeys.Get(ctx, "example.com", "1337")
 err := pdns.Cryptokeys.Delete(ctx, "example.com", "1337")
 ```
 
+### Create/change/delete tsigkeys
+
+```go
+tsigkey, err := pdns.TSIGKey.Create(ctx, "examplekey", "hmac-sha256", "")
+tsigkey, err := pdns.TSIGKey.Change(ctx, "examplekey.", powerdns.TSIGKey{
+	Key: powerdns.String("newkey"),
+})
+tsigkeys, err := pdns.TSIGKey.List(ctx)
+tsigkey, err := pdns.TSIGKey.Get(ctx, "examplekey.")
+err := pdns.TSIGKey.Delete(ctx, "examplekey.")
+```
+
 ### More examples
 
 See [examples](https://github.com/joeig/go-powerdns/tree/master/examples).

--- a/examples/zone-operations/main.go
+++ b/examples/zone-operations/main.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/joeig/go-powerdns/v3"
 	"log"
 	"math/rand"
+
+	"github.com/joeig/go-powerdns/v3"
 )
 
 func main() {
@@ -41,10 +42,17 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 
+	// Create a TSIG Record
+	exampleKey, err := pdns.TSIGKey.Create(ctx, "examplekey", "hmac-sha256", "")
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
 	// Change a zone
 	zoneChangeSet := &powerdns.Zone{
-		Account: powerdns.String("test"),
-		DNSsec:  powerdns.Bool(true),
+		Account:          powerdns.String("test"),
+		DNSsec:           powerdns.Bool(true),
+		MasterTSIGKeyIDs: []string{*exampleKey.ID},
 	}
 
 	if err := pdns.Zones.Change(ctx, domain, zoneChangeSet); err != nil {

--- a/powerdns.go
+++ b/powerdns.go
@@ -34,6 +34,7 @@ type Client struct {
 	Servers    *ServersService
 	Statistics *StatisticsService
 	Zones      *ZonesService
+	TSIGKey    *TSIGKeyService
 }
 
 // logFatalf makes log.Fatalf testable
@@ -67,6 +68,7 @@ func NewClient(baseURL string, vHost string, headers map[string]string, httpClie
 	c.Servers = (*ServersService)(&c.common)
 	c.Statistics = (*StatisticsService)(&c.common)
 	c.Zones = (*ZonesService)(&c.common)
+	c.TSIGKey = (*TSIGKeyService)(&c.common)
 
 	return c
 }

--- a/powerdns_test.go
+++ b/powerdns_test.go
@@ -63,7 +63,7 @@ func registerDoMockResponder() {
 
 func TestNewClient(t *testing.T) {
 	t.Run("TestValidURL", func(t *testing.T) {
-		tmpl := &Client{"http", "localhost", "8080", "localhost", map[string]string{"X-API-Key": "apipw"}, http.DefaultClient, service{}, nil, nil, nil, nil, nil, nil}
+		tmpl := &Client{"http", "localhost", "8080", "localhost", map[string]string{"X-API-Key": "apipw"}, http.DefaultClient, service{}, nil, nil, nil, nil, nil, nil, nil}
 		p := NewClient("http://localhost:8080", "localhost", map[string]string{"X-API-Key": "apipw"}, http.DefaultClient)
 		if p.Hostname != tmpl.Hostname {
 			t.Error("NewClient returns invalid Client object")

--- a/tsigkeys.go
+++ b/tsigkeys.go
@@ -1,0 +1,82 @@
+package powerdns
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// TSIGKeyService handles communication with the tsigs related methods of the Client API
+type TSIGKeyService service
+
+// TSIGKey structure with JSON API metadata
+type TSIGKey struct {
+	Name      *string `json:"name,omitempty"`
+	ID        *string `json:"id,omitempty"`
+	Algorithm *string `json:"algorithm,omitempty"`
+	Key       *string `json:"key,omitempty"`
+	Type      *string `json:"type,omitempty"`
+}
+
+// List retrieves a list of TSIG
+func (t *TSIGKeyService) List(ctx context.Context) ([]TSIGKey, error) {
+	req, err := t.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("servers/%s/tsigkeys", t.client.VHost), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	tsigkeys := make([]TSIGKey, 0)
+	_, err = t.client.do(req, &tsigkeys)
+	return tsigkeys, err
+}
+
+// Get returns a certain TSIG
+func (t *TSIGKeyService) Get(ctx context.Context, id string) (*TSIGKey, error) {
+	req, err := t.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("servers/%s/tsigkeys/%s", t.client.VHost, id), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	tsigkey := TSIGKey{}
+	_, err = t.client.do(req, &tsigkey)
+	return &tsigkey, err
+}
+
+// Create a new TSIG Key setting empty string for secret will generate it
+func (t *TSIGKeyService) Create(ctx context.Context, name, algorithm, secret string) (*TSIGKey, error) {
+	reqTsigkey := TSIGKey{
+		Name:      &name,
+		Algorithm: &algorithm,
+		Key:       &secret,
+	}
+
+	req, err := t.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("servers/%s/tsigkeys", t.client.VHost), nil, reqTsigkey)
+	if err != nil {
+		return nil, err
+	}
+	respTsigkey := TSIGKey{}
+	_, err = t.client.do(req, &respTsigkey)
+
+	return &respTsigkey, err
+}
+
+func (t *TSIGKeyService) Change(ctx context.Context, id string, newTsig TSIGKey) (*TSIGKey, error) {
+	req, err := t.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("servers/%s/tsigkeys/%s", t.client.VHost, id), nil, newTsig)
+	if err != nil {
+		return nil, err
+	}
+	respTsigkey := TSIGKey{}
+	_, err = t.client.do(req, &respTsigkey)
+
+	return &respTsigkey, err
+}
+
+func (t *TSIGKeyService) Delete(ctx context.Context, id string) error {
+	req, err := t.client.newRequest(ctx, http.MethodDelete, fmt.Sprintf("servers/%s/tsigkeys/%s", t.client.VHost, id), nil, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = t.client.do(req, nil)
+	return err
+}

--- a/tsigkeys.go
+++ b/tsigkeys.go
@@ -18,7 +18,7 @@ type TSIGKey struct {
 	Type      *string `json:"type,omitempty"`
 }
 
-// List retrieves a list of TSIG
+// List retrieves a list of TSIGKeys
 func (t *TSIGKeyService) List(ctx context.Context) ([]TSIGKey, error) {
 	req, err := t.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("servers/%s/tsigkeys", t.client.VHost), nil, nil)
 	if err != nil {
@@ -30,7 +30,7 @@ func (t *TSIGKeyService) List(ctx context.Context) ([]TSIGKey, error) {
 	return tsigkeys, err
 }
 
-// Get returns a certain TSIG
+// Get returns a certain TSIGKeys
 func (t *TSIGKeyService) Get(ctx context.Context, id string) (*TSIGKey, error) {
 	req, err := t.client.newRequest(ctx, http.MethodGet, fmt.Sprintf("servers/%s/tsigkeys/%s", t.client.VHost, id), nil, nil)
 	if err != nil {
@@ -42,12 +42,12 @@ func (t *TSIGKeyService) Get(ctx context.Context, id string) (*TSIGKey, error) {
 	return &tsigkey, err
 }
 
-// Create a new TSIG Key setting empty string for secret will generate it
-func (t *TSIGKeyService) Create(ctx context.Context, name, algorithm, secret string) (*TSIGKey, error) {
+// Create a new TSIG Key setting empty string for key will generate it
+func (t *TSIGKeyService) Create(ctx context.Context, name, algorithm, key string) (*TSIGKey, error) {
 	reqTsigkey := TSIGKey{
 		Name:      &name,
 		Algorithm: &algorithm,
-		Key:       &secret,
+		Key:       &key,
 	}
 
 	req, err := t.client.newRequest(ctx, http.MethodPost, fmt.Sprintf("servers/%s/tsigkeys", t.client.VHost), nil, reqTsigkey)
@@ -60,15 +60,15 @@ func (t *TSIGKeyService) Create(ctx context.Context, name, algorithm, secret str
 	return &respTsigkey, err
 }
 
-func (t *TSIGKeyService) Change(ctx context.Context, id string, newTsig TSIGKey) (*TSIGKey, error) {
-	req, err := t.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("servers/%s/tsigkeys/%s", t.client.VHost, id), nil, newTsig)
+func (t *TSIGKeyService) Change(ctx context.Context, id string, newKey TSIGKey) (*TSIGKey, error) {
+	req, err := t.client.newRequest(ctx, http.MethodPut, fmt.Sprintf("servers/%s/tsigkeys/%s", t.client.VHost, id), nil, newKey)
 	if err != nil {
 		return nil, err
 	}
-	respTsigkey := TSIGKey{}
-	_, err = t.client.do(req, &respTsigkey)
+	responseKey := TSIGKey{}
+	_, err = t.client.do(req, &responseKey)
 
-	return &respTsigkey, err
+	return &responseKey, err
 }
 
 func (t *TSIGKeyService) Delete(ctx context.Context, id string) error {

--- a/tsigkeys_integration_test.go
+++ b/tsigkeys_integration_test.go
@@ -1,0 +1,63 @@
+package powerdns_test
+
+import (
+	"context"
+	"log"
+
+	"github.com/joeig/go-powerdns/v3"
+)
+
+var (
+	exampleTSIGKey = powerdns.TSIGKey{
+		Name:      powerdns.String("examplekey"),
+		Algorithm: powerdns.String("hmac-sha256"),
+		Key:       powerdns.String("ruTjBX2Jw/2BlE//5255fmKHaSRvLvp6p+YyDDAXThnBN/1Mz/VwMw+HQJVtkpDsAXvpPuNNZhucdKmhiOS4Tg=="),
+	}
+)
+
+func ExampleTSIGKeyService_Create() {
+	pdns := powerdns.NewClient("http://localhost:8080", "localhost", map[string]string{"X-API-Key": "apipw"}, nil)
+	ctx := context.Background()
+
+	_, err := pdns.TSIGKey.Create(ctx, *exampleTSIGKey.Name, *exampleTSIGKey.Algorithm, "")
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
+}
+
+func ExampleTSIGKeyService_List() {
+	pdns := powerdns.NewClient("http://localhost:8080", "localhost", map[string]string{"X-API-Key": "apipw"}, nil)
+	ctx := context.Background()
+
+	if _, err := pdns.TSIGKey.List(ctx); err != nil {
+		log.Fatalf("%v", err)
+	}
+}
+
+func ExampleTSIGKeyService_Get() {
+	pdns := powerdns.NewClient("http://localhost:8080", "localhost", map[string]string{"X-API-Key": "apipw"}, nil)
+	ctx := context.Background()
+
+	if _, err := pdns.TSIGKey.Get(ctx, *exampleTSIGKey.ID); err != nil {
+		log.Fatalf("%v", err)
+	}
+}
+
+func ExampleTSIGKeyService_Change() {
+	pdns := powerdns.NewClient("http://localhost:8080", "localhost", map[string]string{"X-API-Key": "apipw"}, nil)
+	ctx := context.Background()
+
+	if _, err := pdns.TSIGKey.Change(ctx, *exampleTSIGKey.ID, exampleTSIGKey); err != nil {
+		log.Fatalf("%v", err)
+	}
+}
+
+func ExampleTSIGKeyService_Delete() {
+	pdns := powerdns.NewClient("http://localhost:8080", "localhost", map[string]string{"X-API-Key": "apipw"}, nil)
+	ctx := context.Background()
+
+	if err := pdns.TSIGKey.Delete(ctx, *exampleTSIGKey.ID); err != nil {
+		log.Fatalf("%v", err)
+	}
+}

--- a/tsigkeys_test.go
+++ b/tsigkeys_test.go
@@ -1,0 +1,339 @@
+package powerdns
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"path"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+)
+
+var (
+	serverKey1 = TSIGKey{
+		ID:        String("testkeyonserver."),
+		Name:      String("testkeyonserver"),
+		Algorithm: String("hmac-sha256"),
+		Key:       String("ruTjBX2Jw/2BlE//5255fmKHaSRvLvp6p+YyDDAXThnBN/1Mz/VwMw+HQJVtkpDsAXvpPuNNZhucdKmhiOS4Tg=="),
+		Type:      String("TSIGKey"),
+	}
+	serverKey2 = TSIGKey{
+		ID:        String("testkey2onserver."),
+		Name:      String("testkey2onserver"),
+		Algorithm: String("hmac-sha256"),
+		Key:       String("ruTjBX2Jw/2BlE//5255fmKHaSRvLvp6p+YyDDAXThnBN/1Mz/VwMw+HQJVtkpDsAXvpPuNNZhucdKmhiOS4Tg=="),
+		Type:      String("TSIGKey"),
+	}
+	serverKeyPatch = TSIGKey{
+		ID:        String("testput."),
+		Name:      String("testput"),
+		Algorithm: String("hmac-sha256"),
+		Key:       String("ruTjBX2Jw/2BlE//5255fmKHaSRvLvp6p+YyDDAXThnBN/1Mz/VwMw+HQJVtkpDsAXvpPuNNZhucdKmhiOS4Tg=="),
+		Type:      String("TSIGKey"),
+	}
+)
+
+func registerTSIGKeyMockReponder(tsigKeys *[]TSIGKey) {
+
+	httpmock.RegisterResponder(http.MethodGet, generateTestAPIVHostURL()+"/tsigkeys",
+		func(req *http.Request) (*http.Response, error) {
+			if res := verifyAPIKey(req); res != nil {
+				return res, nil
+			}
+			return httpmock.NewJsonResponse(http.StatusOK, tsigKeys)
+		},
+	)
+
+	httpmock.RegisterResponder(http.MethodPost, generateTestAPIVHostURL()+"/tsigkeys",
+		func(req *http.Request) (*http.Response, error) {
+			if res := verifyAPIKey(req); res != nil {
+				return res, nil
+			}
+
+			if req.Body == nil {
+				log.Print("Request body is nil")
+				return httpmock.NewBytesResponse(http.StatusBadRequest, []byte{}), nil
+			}
+
+			var clientTsigkey TSIGKey
+			if json.NewDecoder(req.Body).Decode(&clientTsigkey) != nil {
+				log.Print("Cannot decode request body")
+				return httpmock.NewBytesResponse(http.StatusBadRequest, []byte{}), nil
+			}
+
+			clientTsigkey.ID = String(*clientTsigkey.Name + ".")
+			clientTsigkey.Type = String("TSIGKey")
+			for _, serverTsigkey := range *tsigKeys {
+				if *serverTsigkey.ID == *clientTsigkey.ID {
+					return httpmock.NewBytesResponse(http.StatusConflict, []byte{}), nil
+				}
+			}
+
+			return httpmock.NewJsonResponse(http.StatusCreated, clientTsigkey)
+		},
+	)
+
+	for _, tsigkey := range *tsigKeys {
+
+		httpmock.RegisterResponder(http.MethodGet, generateTestAPIVHostURL()+"/tsigkeys/"+*tsigkey.ID,
+			func(req *http.Request) (*http.Response, error) {
+				if res := verifyAPIKey(req); res != nil {
+					return res, nil
+				}
+
+				return httpmock.NewJsonResponse(http.StatusOK, tsigkey)
+			},
+		)
+
+		httpmock.RegisterResponder(http.MethodPut, generateTestAPIVHostURL()+"/tsigkeys/"+*tsigkey.ID,
+			func(req *http.Request) (*http.Response, error) {
+				if res := verifyAPIKey(req); res != nil {
+					return res, nil
+				}
+
+				if req.Body == nil {
+					log.Print("Request body is nil")
+					return httpmock.NewBytesResponse(http.StatusBadRequest, []byte{}), nil
+				}
+				var clientTsigkey TSIGKey
+				if json.NewDecoder(req.Body).Decode(&clientTsigkey) != nil {
+					log.Print("Cannot decode request body")
+					return httpmock.NewBytesResponse(http.StatusBadRequest, []byte{}), nil
+				}
+
+				for _, serverTsigkey := range *tsigKeys {
+					if *serverTsigkey.ID == path.Base(req.URL.Path) {
+						continue
+					}
+					if *serverTsigkey.ID == *clientTsigkey.ID {
+						return httpmock.NewBytesResponse(http.StatusConflict, []byte{}), nil
+					}
+				}
+
+				return httpmock.NewJsonResponse(http.StatusOK, clientTsigkey)
+			},
+		)
+		httpmock.RegisterResponder(http.MethodDelete, generateTestAPIVHostURL()+"/tsigkeys/"+*tsigkey.ID,
+			func(req *http.Request) (*http.Response, error) {
+				if res := verifyAPIKey(req); res != nil {
+					return res, nil
+				}
+
+				return httpmock.NewBytesResponse(http.StatusNoContent, []byte{}), nil
+			},
+		)
+	}
+}
+
+func TestCreateTSIGKey(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	p := initialisePowerDNSTestClient()
+	registerTSIGKeyMockReponder(&[]TSIGKey{
+		serverKey1,
+	})
+
+	testCases := []struct {
+		tsigkey     TSIGKey
+		wantSuccess bool
+	}{
+		{
+			TSIGKey{
+				Name:      String("testgen"),
+				Algorithm: String("hmac-sha256"),
+				Key:       String(""),
+			},
+			true,
+		},
+		{
+			TSIGKey{
+				Name:      String("testfull"),
+				Algorithm: String("hmac-sha256"),
+				Key:       String("kjhOh/NLyHVwPxFwBrwYs043A99hFDycWwYi1Nj6R2bM3Rboh515yIbEIzzQx9Xod0W6nN8vnSAAvsysrgkOPw=="),
+			},
+			true,
+		},
+		{
+			TSIGKey{
+				Name:      String("testkeyonserver"),
+				Algorithm: String("hmac-sha256"),
+				Key:       String(""),
+			},
+			false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("TestCase%d", i), func(t *testing.T) {
+			respTSIGKey, err := p.TSIGKey.Create(context.Background(), *tc.tsigkey.Name, *tc.tsigkey.Algorithm, *tc.tsigkey.Key)
+			if !tc.wantSuccess {
+				if err == nil {
+					t.Error("no error on duplicate key")
+				}
+				return
+			}
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			if *respTSIGKey.Name != *tc.tsigkey.Name || *respTSIGKey.Algorithm != *tc.tsigkey.Algorithm {
+				t.Errorf("input name or algorithm did not match with output: name: %s, %s; algorithm: %s, %s", *respTSIGKey.Name, *tc.tsigkey.Name, *respTSIGKey.Algorithm, *tc.tsigkey.Algorithm)
+			}
+		})
+	}
+}
+
+func TestPatchTSIGKey(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	p := initialisePowerDNSTestClient()
+	registerTSIGKeyMockReponder(&[]TSIGKey{
+		serverKey1,
+		serverKeyPatch,
+	})
+
+	testCases := []struct {
+		tsigkey     TSIGKey
+		wantSuccess bool
+	}{
+		{
+			tsigkey: TSIGKey{
+				ID:        String("testput."),
+				Name:      String("testput"),
+				Algorithm: String("hmac-sha256"),
+				Key:       String("1yWS55DxB2H40lded3/2IGnhbW6dCntvO+igEcP47n2ikD1EO03NDGKsKValitiqrtAmk41UbYVpREN23GYAdg=="),
+			},
+			wantSuccess: false,
+		},
+		{
+			tsigkey: TSIGKey{
+				ID:        String("testkeyonserver."),
+				Name:      String("testkeyonserver"),
+				Algorithm: String("hmac-sha256"),
+				Key:       String("1yWS55DxB2H40lded3/2IGnhbW6dCntvO+igEcP47n2ikD1EO03NDGKsKValitiqrtAmk41UbYVpREN23GYAdg=="),
+				Type:      String("TSIGKey"),
+			},
+			wantSuccess: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("TestCase%d", i), func(t *testing.T) {
+			_, err := p.TSIGKey.Change(context.Background(), "testkeyonserver.", tc.tsigkey)
+			if !tc.wantSuccess {
+				if err == nil {
+					t.Error("expected error. but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func TestTSIGKeyErrorNewRequests(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	p := initialisePowerDNSTestClient()
+	p.Port = "x"
+	registerTSIGKeyMockReponder(&[]TSIGKey{})
+
+	t.Run("Test Get invalid request", func(t *testing.T) {
+		_, err := p.TSIGKey.Get(context.Background(), "thiskeydoesnotexist.")
+		if err == nil {
+			t.Error("error is nil")
+		}
+	})
+	t.Run("Test List invalid request", func(t *testing.T) {
+		_, err := p.TSIGKey.List(context.Background())
+		if err == nil {
+			t.Error("error is nil")
+		}
+	})
+	t.Run("Test Create invalid request", func(t *testing.T) {
+		_, err := p.TSIGKey.Create(context.Background(), "test", "hmac-sha256", "")
+		if err == nil {
+			t.Error("error is nil")
+		}
+	})
+	t.Run("Test Change invalid request", func(t *testing.T) {
+		_, err := p.TSIGKey.Change(context.Background(), "test", TSIGKey{})
+		if err == nil {
+			t.Error("error is nil")
+		}
+	})
+	t.Run("Test Delete invalid request", func(t *testing.T) {
+		err := p.TSIGKey.Delete(context.Background(), "test")
+		if err == nil {
+			t.Error("error is nil")
+		}
+	})
+}
+
+func TestGetTSIGKey(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	p := initialisePowerDNSTestClient()
+	serverTSIGKeys := &[]TSIGKey{
+		serverKey1,
+		serverKey2,
+	}
+
+	registerTSIGKeyMockReponder(serverTSIGKeys)
+
+	t.Run("Test Get", func(t *testing.T) {
+		_, err := p.TSIGKey.Get(context.Background(), "testkeyonserver.")
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("Test List", func(t *testing.T) {
+		tsigkeys, err := p.TSIGKey.List(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(*serverTSIGKeys) != len(tsigkeys) {
+			t.Errorf("wrong amount of elements returned. expected %d, got %d", len(*serverTSIGKeys), len(tsigkeys))
+			return
+		}
+
+	})
+}
+
+func TestDeleteTSIGKey(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	p := initialisePowerDNSTestClient()
+	registerTSIGKeyMockReponder(&[]TSIGKey{
+		serverKey1,
+		serverKey2,
+	})
+
+	t.Run("Remove existing TSIG Key", func(t *testing.T) {
+		err := p.TSIGKey.Delete(context.Background(), *serverKey1.ID)
+		if err != nil {
+			t.Errorf("expected successfull delete got error: %v", err)
+			return
+		}
+	})
+
+	t.Run("Remove non-existing TSIG Key", func(t *testing.T) {
+		err := p.TSIGKey.Delete(context.Background(), "doesnotexist.")
+		if err == nil {
+			t.Errorf("expected err. but got nil")
+		}
+	})
+}

--- a/tsigkeys_test.go
+++ b/tsigkeys_test.go
@@ -36,7 +36,7 @@ var (
 	}
 )
 
-func registerTSIGKeyMockReponder(tsigKeys *[]TSIGKey) {
+func registerTSIGKeyMockResponder(tsigKeys *[]TSIGKey) {
 
 	httpmock.RegisterResponder(http.MethodGet, generateTestAPIVHostURL()+"/tsigkeys",
 		func(req *http.Request) (*http.Response, error) {
@@ -133,7 +133,7 @@ func TestCreateTSIGKey(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	p := initialisePowerDNSTestClient()
-	registerTSIGKeyMockReponder(&[]TSIGKey{
+	registerTSIGKeyMockResponder(&[]TSIGKey{
 		serverKey1,
 	})
 
@@ -193,7 +193,7 @@ func TestPatchTSIGKey(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	p := initialisePowerDNSTestClient()
-	registerTSIGKeyMockReponder(&[]TSIGKey{
+	registerTSIGKeyMockResponder(&[]TSIGKey{
 		serverKey1,
 		serverKeyPatch,
 	})
@@ -245,7 +245,7 @@ func TestTSIGKeyErrorNewRequests(t *testing.T) {
 
 	p := initialisePowerDNSTestClient()
 	p.Port = "x"
-	registerTSIGKeyMockReponder(&[]TSIGKey{})
+	registerTSIGKeyMockResponder(&[]TSIGKey{})
 
 	t.Run("Test Get invalid request", func(t *testing.T) {
 		_, err := p.TSIGKey.Get(context.Background(), "thiskeydoesnotexist.")
@@ -289,7 +289,7 @@ func TestGetTSIGKey(t *testing.T) {
 		serverKey2,
 	}
 
-	registerTSIGKeyMockReponder(serverTSIGKeys)
+	registerTSIGKeyMockResponder(serverTSIGKeys)
 
 	t.Run("Test Get", func(t *testing.T) {
 		_, err := p.TSIGKey.Get(context.Background(), "testkeyonserver.")
@@ -317,7 +317,7 @@ func TestDeleteTSIGKey(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	p := initialisePowerDNSTestClient()
-	registerTSIGKeyMockReponder(&[]TSIGKey{
+	registerTSIGKeyMockResponder(&[]TSIGKey{
 		serverKey1,
 		serverKey2,
 	})


### PR DESCRIPTION
implements #69.

First time writing unit/integration tests. I hope they are alright.

I'm also not sure if my implementation of
```go
tsigkey, err := pdns.TSIGKey.Change(ctx, "examplekey.", powerdns.TSIGKey{
	Key: powerdns.String("newkey"),
})
```
fits the general style.
Looking forward to your feedback. Any feedback is appreciated :)