### PR TITLE
Pin vladopajic/go-test-coverage to v2.8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: make coverage
       - name: Check test coverage threshold
         id: coverage
-        uses: vladopajic/go-test-coverage@v2
+        uses: vladopajic/go-test-coverage@v2.8.0
         with:
           config: ./.github/testcoverage.yml
   test-without-mocks:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.1
+          version: v1.55.2
       - name: Staticcheck
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: make coverage
       - name: Check test coverage threshold
         id: coverage
-        uses: vladopajic/go-test-coverage@v2.8.0
+        uses: vladopajic/go-test-coverage@v2.8.1
         with:
           config: ./.github/testcoverage.yml
   test-without-mocks:


### PR DESCRIPTION
v2.8.2 seems to be affected by a bug.

```
failed to generate coverage statistics: could not find file [github.com/joeig/go-powerdns/v3/config.go]: can't find "config.go": go/build: go list github.com/joeig/go-powerdns/v3/: exit status 1
go: github.com/jarcoal/httpmock@v1.3.1: GOPROXY list is not the empty string, but contains no entries
```

Reference: https://github.com/joeig/go-powerdns/actions/runs/7168084065/job/19892527626?pr=68